### PR TITLE
Configuration from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.yml

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,15 @@
+errbit_url: http://errbit-demo.herokuapp.com
+apps:
+  - Demo
+errors:
+  - Can't connect to MySQL server
+  - Mysql2::Error: Server shutdown in progress
+  - MySQL server has gone away
+  - closed MySQL connection
+  - Lost connection to MySQL server
+  - MySQL client is not connected
+  - ^Net::ReadTimeout: Net::ReadTimeout$
+  - ^Net::OpenTimeout: execution expired$
+  - ^Timeout::Error: Timeout::Error$
+# errbit_username: user
+# errbit_password: pass

--- a/errwipe
+++ b/errwipe
@@ -1,30 +1,23 @@
 #!/usr/bin/env ruby
 
 require_relative 'lib/errwipe'
+require 'pathname'
 
 wiper = Errwipe::Wiper.new do |c|
-  c.errbit_url = ENV['ERRWIPE_ERRBIT_URL'] || 'http://errbit-demo.herokuapp.com'
+  config_file = Errwipe::ConfigurationFile.new(
+    Pathname.new('config.yml').expand_path
+  )
 
-  c.apps = if ENV['ERRWIPE_APPS']
-             ENV['ERRWIPE_APPS'].split(',').map do |re|
-               /#{re}/i
-             end
-           else
-             [/Demo/i]
-           end
+  c.errbit_url = config_file['errbit_url'] || 'http://errbit-demo.herokuapp.com'
 
-  c.errors = [/Can't connect to MySQL server/,
-              /MySQL server has gone away/,
-              /closed MySQL connection/,
-              /Lost connection to MySQL server/,
-              /MySQL client is not connected/,
-              /^Net::ReadTimeout: Net::ReadTimeout$/,
-              /^Net::OpenTimeout: execution expired$/,
-              /^Timeout::Error: Timeout::Error$/]
+  app_names = config_file['apps'] || ['Demo']
+  c.apps = app_names.map { |re| /#{re}/i }
+
+  c.errors = (config_file['errors'] || []).map { |re| /#{re}/ }
 
   prompt = Errwipe::CredentialPrompt.new
-  c.username = prompt.username
-  c.password = prompt.password
+  c.username = config_file['errbit_username'] || prompt.username
+  c.password = config_file['errbit_password'] || prompt.password
   puts
 end
 

--- a/lib/errwipe.rb
+++ b/lib/errwipe.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'rubygems'
 require 'mechanize'
 
@@ -7,5 +5,9 @@ require_relative 'errwipe/configuration_file'
 require_relative 'errwipe/credential_prompt'
 require_relative 'errwipe/wiper'
 
+# Errwipe helps to wipe errors from errbit-project
+#
+# Some errors are beyond our control and can be removed. Errwipe does this
+# faster.
 module Errwipe
 end

--- a/lib/errwipe.rb
+++ b/lib/errwipe.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'mechanize'
 
+require_relative 'errwipe/configuration_file'
 require_relative 'errwipe/credential_prompt'
 require_relative 'errwipe/wiper'
 

--- a/lib/errwipe/configuration_file.rb
+++ b/lib/errwipe/configuration_file.rb
@@ -1,0 +1,15 @@
+require 'yaml'
+
+module Errwipe
+  # Wrapper to load the configuration from a file and read individual settings
+  class ConfigurationFile
+    def initialize(filename)
+      @filename = filename
+      @config   = YAML.load_file(@filename)
+    end
+
+    def [](key)
+      @config[key.to_s]
+    end
+  end
+end


### PR DESCRIPTION
As mentioned in #3 added a config-file to read from.

The defaults from earlier are still included, but the ENV-approach is dropped with this. Migration from two ENV-vars to a config-file is IMHO easy enough to not provide an fully automated upgrade-path. If that is needed, I would do it in separate PR.

While at it, I added another error to the example-config.